### PR TITLE
fix autoload mapping for NasExt\Forms\DI namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
 	},
 	"autoload": {
 		"psr-0": {
-			"NasExt\\Forms\\Controls\\": "src/"
+			"NasExt\\Forms\\": "src/"
 		}
 	}
 }


### PR DESCRIPTION
fix autoload mapping for NasExt\Forms\DI namespace