### PR TITLE
Support for Nette\Utils\Html object as select input items

### DIFF
--- a/client-side/dependentSelectBox.js
+++ b/client-side/dependentSelectBox.js
@@ -98,6 +98,14 @@
 									var option = $('<option>')
 										.attr('value', item.key).text(item.value);
 
+									if ('title' in item) {
+										option.attr('title', item.title);
+									}
+
+									if ('disabled' in item) {
+										option.attr('disabled', item.disabled);
+									}
+
 									if (data.value !== null && item.key == data.value) {
 										option.attr('selected', true);
 									}

--- a/src/NasExt/Forms/Controls/DependentSelectBox.php
+++ b/src/NasExt/Forms/Controls/DependentSelectBox.php
@@ -289,10 +289,19 @@ class DependentSelectBox extends SelectBox implements ISignalReceiver
 	{
 		$newItems = array();
 		foreach ($items as $key => $item) {
-			$newItems[] = array(
-				'key' => $key,
-				'value' => $item,
-			);
+			if ($item instanceof \Nette\Utils\Html) {
+				$newItems[] = array(
+					'key' => $item->getValue(),
+					'value' => $item->getText(),
+					'title' => $item->getTitle(),
+					'disabled' => $item->getDisabled(),
+				);
+			} else {
+				$newItems[] = array(
+					'key' => $key,
+					'value' => $item,
+				);
+			}
 		}
 		return $newItems;
 	}


### PR DESCRIPTION
Sometimes i need set the items of select input like array below, so this pull request fix the problems with this solution.
```php
$items[] = Utils\Html::el("option")->value(1)->setText("Value 1")->disabled(FALSE)->setTitle("Help text");
$items[] = Utils\Html::el("option")->value(2)->setText("Value 2")->disabled(FALSE)->setTitle("Help text");
$items[] = Utils\Html::el("option")->value(3)->setText("Value 3")->disabled(TRUE)->setTitle("Help text");
```