### PR TITLE
Better solution for adding the attributes for option tag

### DIFF
--- a/client-side/dependentSelectBox.js
+++ b/client-side/dependentSelectBox.js
@@ -98,12 +98,10 @@
 									var option = $('<option>')
 										.attr('value', item.key).text(item.value);
 
-									if ('title' in item) {
-										option.attr('title', item.title);
-									}
-
-									if ('disabled' in item) {
-										option.attr('disabled', item.disabled);
+									if ('attributes' in item) {
+										$.each(item.attributes, function (attr, attrValue) {
+											option.attr(attr, attrValue);
+										});
 									}
 
 									if (data.value !== null && item.key == data.value) {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,11 @@
 	"license": "MIT",
 	"main": "client-side/dependentSelectBox.js",
 	"files": [
-		"client-side"
-	]
+		"client-side",
+		"README.md"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/aleswita/DependentSelectBox.git"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "nas-ext-dependent-select-box",
-	"version": "2.7.1",
+	"version": "2.7.3",
 	"description": "DependentSelectBox for Nette Framework",
 	"keywords": [
 		"nette",
@@ -17,6 +17,6 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/aleswita/DependentSelectBox.git"
+		"url": "git+https://github.com/NasExt/DependentSelectBox.git"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "nas-ext-dependent-select-box",
+	"version": "2.7.1",
+	"description": "DependentSelectBox for Nette Framework",
+	"keywords": [
+		"nette",
+		"nasext",
+		"DependentSelectBox"
+	],
+	"author": "Dusan Hudak",
+	"author": "Jáchym Toušek",
+	"license": "MIT",
+	"main": "client-side/dependentSelectBox.js",
+	"files": [
+		"client-side"
+	]
+}

--- a/src/NasExt/Forms/Controls/DependentSelectBox.php
+++ b/src/NasExt/Forms/Controls/DependentSelectBox.php
@@ -288,14 +288,20 @@ class DependentSelectBox extends SelectBox implements ISignalReceiver
 	private function prepareItems($items)
 	{
 		$newItems = array();
+
 		foreach ($items as $key => $item) {
 			if ($item instanceof \Nette\Utils\Html) {
 				$newItems[] = array(
 					'key' => $item->getValue(),
 					'value' => $item->getText(),
-					'title' => $item->getTitle(),
-					'disabled' => $item->getDisabled(),
 				);
+
+				end($newItems);
+				$key = key($newItems);
+
+				foreach ($item->attrs as $attribute => $value) {
+					$newItems[$key]['attributes'][$attribute] = $value;
+				}
 			} else {
 				$newItems[] = array(
 					'key' => $key,


### PR DESCRIPTION
Because, the **tittle** attribute in **option** tag it is not valid, here is the better solution for adding attribute, what will you need.

+added **package.json** file

**There is no BC breaks, you can mark this version as 2.7.1**


In czech: ten file package.json slouzi k nainstalovani klient side skriptum, poprve co jsem nejaky balicek v NPI publikoval, takze nevim jestli se to bude updatovat pri kazde verzi automaticky, nebo se to bude muset delat manualne, nicmene, pokud si vytvorite ucet na www.npmjs.com, tak vam muzu predat pravomoce pro spravu.

```sh
$ npi install nas-ext-dependent-select-box@~2.7.0

$ yarn add nas-ext-dependent-select-box@~2.7.0
```