### PR TITLE
Correctly sending values of checkboxes

### DIFF
--- a/client-side/dependentSelectBox.js
+++ b/client-side/dependentSelectBox.js
@@ -40,11 +40,17 @@
 			$.each(parents, function (name, id) {
 				var parentElement = $('#' + id);
 				if (parentElement.length > 0) {
-					var val = $(parentElement).val();
-					if (val) {
-						signalLink = signalLink + '&' + name + '=' + val;
-					}
-
+					var val;
+                    if (parentElement.prop('type') === 'checkbox') {
+                        val = parentElement.prop('checked') ? 1 : 0;
+                    }
+                    else {
+                        val = $(parentElement).val();
+                        if (!val) {
+                            return;
+                        }
+                    }
+                    signalLink = signalLink + '&' + name + '=' + val;
 				}
 			});
 

--- a/client-side/dependentSelectBox.js
+++ b/client-side/dependentSelectBox.js
@@ -41,16 +41,16 @@
 				var parentElement = $('#' + id);
 				if (parentElement.length > 0) {
 					var val;
-                    if (parentElement.prop('type') === 'checkbox') {
-                        val = parentElement.prop('checked') ? 1 : 0;
-                    }
-                    else {
-                        val = $(parentElement).val();
-                        if (!val) {
-                            return;
-                        }
-                    }
-                    signalLink = signalLink + '&' + name + '=' + val;
+                    			if (parentElement.prop('type') === 'checkbox') {
+                        			val = parentElement.prop('checked') ? 1 : 0;
+                    			}
+                    			else {
+                        			val = $(parentElement).val();
+						if (!val) {
+						    return;
+						}
+					}
+                    			signalLink = signalLink + '&' + name + '=' + val;
 				}
 			});
 


### PR DESCRIPTION
This PR improves sending values of checkboxes to the server. Until now checkbox values were accessed by .val(). This method wasn't working correctly. This PR checks for input type, and if it's checkbox, value is accessed by .prop('checked'). Result is then converted to integer - othervise your PHP server gets string containing 'true' or 'false'.