### PR TITLE
Do not lock Nette Utils 2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
 	],
 	"require": {
 		"php": "~5.6.0 || ~7.0",
-		"nette/application": "~2.4.0 || ~3.0.0",
-		"nette/forms": "~2.4.0 || ~3.0.0",
-		"nette/utils": "~2.4.0 || ~3.0.0"
+		"nette/application": "~2.4 || ~3.0.0",
+		"nette/forms": "~2.4 || ~3.0.0",
+		"nette/utils": "~2.4 || ~3.0.0"
 	},
 	"require-dev": {
 		"nette/di": "~2.4.6 || ~3.0.0",

--- a/composer.json
+++ b/composer.json
@@ -17,19 +17,19 @@
 		}
 	],
 	"require": {
-		"php": "~5.6.0 || ~7.0",
-		"nette/application": "~2.4 || ~3.0.0",
-		"nette/forms": "~2.4 || ~3.0.0",
-		"nette/utils": "~2.4 || ~3.0.0"
+		"php": "~5.6.0 || ^7.0",
+		"nette/application": "^2.4 || ~3.0.0",
+		"nette/forms": "^2.4 || ~3.0.0",
+		"nette/utils": "^2.4 || ~3.0.0"
 	},
 	"require-dev": {
-		"nette/di": "~2.4.6 || ~3.0.0",
-		"nette/robot-loader": "~2.4.0 || ~3.0.0",
-		"nette/bootstrap": "~2.4.0 || ~3.0.0",
-		"nette/http": "~2.4.0 || ~3.0.0",
-		"tracy/tracy": "~2.4.0 || ~3.0.0",
-		"nette/tester": "~2.0.0",
-		"latte/latte": "~2.4.0 || ~3.0.0"
+		"nette/di": "^2.4.6 || ~3.0.0",
+		"nette/robot-loader": "^2.4 || ~3.0.0",
+		"nette/bootstrap": "^2.4 || ~3.0.0",
+		"nette/http": "^2.4 || ~3.0.0",
+		"tracy/tracy": "^2.4 || ~3.0.0",
+		"nette/tester": "^2.0",
+		"latte/latte": "^2.4 || ~3.0.0"
 	},
 	"autoload": {
 		"classmap": ["src/"]


### PR DESCRIPTION
Version `3.0+` working with Nette\Utils `2.5` - there is no reason to disallowed it.

Tested in fork on our project.