### PR TITLE
Nette 3.0 compatibility + multiselect fix

### DIFF
--- a/src/Controls/DependentMultiSelectBox.php
+++ b/src/Controls/DependentMultiSelectBox.php
@@ -23,7 +23,9 @@ use Nette;
  */
 class DependentMultiSelectBox extends Nette\Forms\Controls\MultiSelectBox implements Nette\Application\UI\ISignalReceiver
 {
-	use NasExt\Forms\DependentTrait;
+	use NasExt\Forms\DependentTrait {
+	    getValue as protected traitGetValue;
+    }
 
 	/** @var string */
 	const SIGNAL_NAME = DependentSelectBox::SIGNAL_NAME;
@@ -56,6 +58,15 @@ class DependentMultiSelectBox extends Nette\Forms\Controls\MultiSelectBox implem
 
 
 	/**
+	 * @return array
+     	 */
+	public function getValue(): array
+	{
+		return $this->traitGetValue();
+	}
+
+
+    	/**
 	 * @param string $signal
 	 * @return void
 	 */
@@ -66,7 +77,9 @@ class DependentMultiSelectBox extends Nette\Forms\Controls\MultiSelectBox implem
 		if ($presenter->isAjax() && $signal === self::SIGNAL_NAME && !$this->isDisabled()) {
 			$parentsNames = [];
 			foreach ($this->parents as $parent) {
-				$value = $presenter->getParameter($this->getNormalizeName($parent));
+				$value = explode(',', $presenter->getParameter($this->getNormalizeName($parent)));
+				$value = array_filter($value, static function ($val) {return !in_array($val, [null, '', []], true);});
+
 				$parent->setValue($value);
 
 				$parentsNames[$parent->getName()] = $parent->getValue();

--- a/src/Controls/DependentMultiSelectBox.php
+++ b/src/Controls/DependentMultiSelectBox.php
@@ -77,8 +77,12 @@ class DependentMultiSelectBox extends Nette\Forms\Controls\MultiSelectBox implem
 		if ($presenter->isAjax() && $signal === self::SIGNAL_NAME && !$this->isDisabled()) {
 			$parentsNames = [];
 			foreach ($this->parents as $parent) {
-				$value = explode(',', $presenter->getParameter($this->getNormalizeName($parent)));
-				$value = array_filter($value, static function ($val) {return !in_array($val, [null, '', []], true);});
+				$value = $presenter->getParameter($this->getNormalizeName($parent));
+				
+				if ($parent instanceof Nette\Forms\Controls\MultiChoiceControl) {
+					$value = explode(',', $value);
+				    	$value = array_filter($value, static function ($val) {return !in_array($val, [null, '', []], true);});
+				}
 
 				$parent->setValue($value);
 

--- a/src/Controls/DependentMultiSelectBox.php
+++ b/src/Controls/DependentMultiSelectBox.php
@@ -59,7 +59,7 @@ class DependentMultiSelectBox extends Nette\Forms\Controls\MultiSelectBox implem
 	 * @param string $signal
 	 * @return void
 	 */
-	public function signalReceived($signal)
+	public function signalReceived(string $signal) : void
 	{
 		$presenter = $this->lookup('Nette\\Application\\UI\\Presenter');
 

--- a/src/Controls/DependentSelectBox.php
+++ b/src/Controls/DependentSelectBox.php
@@ -44,7 +44,7 @@ class DependentSelectBox extends Nette\Forms\Controls\SelectBox implements Nette
 	 * @param string $signal
 	 * @return void
 	 */
-	public function signalReceived($signal)
+	public function signalReceived(string $signal) : void
 	{
 		$presenter = $this->lookup('Nette\\Application\\UI\\Presenter');
 

--- a/src/Controls/DependentSelectBox.php
+++ b/src/Controls/DependentSelectBox.php
@@ -52,6 +52,12 @@ class DependentSelectBox extends Nette\Forms\Controls\SelectBox implements Nette
 			$parentsNames = [];
 			foreach ($this->parents as $parent) {
 				$value = $presenter->getParameter($this->getNormalizeName($parent));
+				
+				if ($parent instanceof Nette\Forms\Controls\MultiChoiceControl) {
+					$value = explode(',', $value);
+				    	$value = array_filter($value, static function ($val) {return !in_array($val, [null, '', []], true);});
+				}
+
 				$parent->setValue($value);
 
 				$parentsNames[$parent->getName()] = $parent->getValue();

--- a/src/DependentTrait.php
+++ b/src/DependentTrait.php
@@ -37,7 +37,7 @@ trait DependentTrait
 	/**
 	 * @return Nette\Utils\Html
 	 */
-	public function getControl()
+	public function getControl() : Nette\Utils\Html
 	{
 		$this->tryLoadItems();
 
@@ -112,7 +112,7 @@ trait DependentTrait
 			throw new NasExt\Forms\DependentCallbackException('Dependent callback for "' . $this->getHtmlId() . '" must be set!');
 		}
 
-		$dependentData = Nette\Utils\Callback::invokeArgs($this->dependentCallback, $args);
+		$dependentData = call_user_func_array($this->dependentCallback, $args);
 
 		if (!($dependentData instanceof NasExt\Forms\DependentData) && !($dependentData instanceof NasExt\Forms\Controls\DependentSelectBoxData)) {
 			throw new NasExt\Forms\DependentCallbackException('Callback for "' . $this->getHtmlId() . '" must return NasExt\\Forms\\DependentData instance!');


### PR DESCRIPTION
**Nette 3.0 compatibility:**

- added parameter & return type hints for multiple methods
- replaced invokeArgs with native callback

**Multiselect problem:**

Multiselect's setValue method depended on nette's internal conversion of scalar value to array (in MulltiChoiceControl::setValue()), which caused problems in new type system. Additionally, value provided from presenter was comma-separated string.

- improved Multiselects signalRecieved method, which converts comma-separated string value to array

