### PR TITLE
Raised minimal PHP version to 7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
 		}
 	],
 	"require": {
-		"php": "~5.6.0 || ^7.0",
+		"php": "^7.1",
 		"nette/application": "^2.4 || ~3.0.0",
 		"nette/forms": "^2.4 || ~3.0.0",
 		"nette/utils": "^2.4 || ~3.0.0"


### PR DESCRIPTION
Použité return type hinty vyžadují min 7.1.

Pravděpodobně bude třeba vylepšit ještě Travis konfiguraci.