### PR TITLE
preserve order of $items on client

### DIFF
--- a/src/DependentData.php
+++ b/src/DependentData.php
@@ -136,7 +136,8 @@ class DependentData
 				$this->addElementToItemsList($items, $el);
 			}
 		}
-		return $items;
+		// make a List so the order of items is preserved when sent as JSON to client
+		return array_values($items);
 	}
 
 


### PR DESCRIPTION
make $items a List so the order of items is preserved when sent as JSON to client