### PR TITLE
Add type checks to multi choice signal procesing

### DIFF
--- a/src/Controls/DependentMultiSelectBox.php
+++ b/src/Controls/DependentMultiSelectBox.php
@@ -80,7 +80,7 @@ class DependentMultiSelectBox extends Nette\Forms\Controls\MultiSelectBox implem
 				$value = $presenter->getParameter($this->getNormalizeName($parent));
 				
 				if ($parent instanceof Nette\Forms\Controls\MultiChoiceControl) {
-					if (is_string($value) {
+					if (is_string($value)) {
 						$value = explode(',', $value);
 					}
 					if ($value !== null) {

--- a/src/Controls/DependentMultiSelectBox.php
+++ b/src/Controls/DependentMultiSelectBox.php
@@ -80,8 +80,12 @@ class DependentMultiSelectBox extends Nette\Forms\Controls\MultiSelectBox implem
 				$value = $presenter->getParameter($this->getNormalizeName($parent));
 				
 				if ($parent instanceof Nette\Forms\Controls\MultiChoiceControl) {
-					$value = explode(',', $value);
-				    	$value = array_filter($value, static function ($val) {return !in_array($val, [null, '', []], true);});
+					if (is_string($value) {
+						$value = explode(',', $value);
+					}
+					if ($value !== null) {
+						$value = array_filter($value, static function ($val) {return !in_array($val, [null, '', []], true);});
+					}
 				}
 
 				$parent->setValue($value);

--- a/src/Controls/DependentSelectBox.php
+++ b/src/Controls/DependentSelectBox.php
@@ -54,8 +54,13 @@ class DependentSelectBox extends Nette\Forms\Controls\SelectBox implements Nette
 				$value = $presenter->getParameter($this->getNormalizeName($parent));
 				
 				if ($parent instanceof Nette\Forms\Controls\MultiChoiceControl) {
-					$value = explode(',', $value);
-				    	$value = array_filter($value, static function ($val) {return !in_array($val, [null, '', []], true);});
+					if (is_string($value) {
+						$value = explode(',', $value);
+					}
+
+					if ($value !== null) {
+						$value = array_filter($value, static function ($val) {return !in_array($val, [null, '', []], true);});
+					}
 				}
 
 				$parent->setValue($value);

--- a/src/Controls/DependentSelectBox.php
+++ b/src/Controls/DependentSelectBox.php
@@ -54,7 +54,7 @@ class DependentSelectBox extends Nette\Forms\Controls\SelectBox implements Nette
 				$value = $presenter->getParameter($this->getNormalizeName($parent));
 				
 				if ($parent instanceof Nette\Forms\Controls\MultiChoiceControl) {
-					if (is_string($value) {
+					if (is_string($value)) {
 						$value = explode(',', $value);
 					}
 


### PR DESCRIPTION
Values from multiple choice select are returned as an array, not a string in latest Nette versions.

Also value might be a `null` if not set.